### PR TITLE
Unlink Init-class from a file (includes: Reducing multiton-behaviour)

### DIFF
--- a/lib/IDS/Init.php
+++ b/lib/IDS/Init.php
@@ -69,85 +69,41 @@ class Init
     private static $instances = array();
 
     /**
-     * Path to the config file
-     *
-     * @var string
-     */
-    private $configPath = null;
-
-    /**
      * Constructor
      *
      * Includes needed classes and parses the configuration file
      *
-     * @param string $configPath the path to the config file
+     * @param array $config
      *
-     * @return object $this
+     * @return \IDS\Init $this
      */
-    private function __construct($configPath = null)
+    public function __construct(array $config = array())
     {
-        if ($configPath) {
-            $this->setConfigPath($configPath);
-            $this->config = parse_ini_file($this->configPath, true);
-        }
-    }
-
-    /**
-     * Permitting to clone this object
-     *
-     * For the sake of correctness of a singleton pattern, this is necessary
-     *
-     * @return void
-     */
-    final public function __clone()
-    {
+        $this->config = $config;
     }
 
     /**
      * Returns an instance of this class. Also a PHP version check
      * is being performed to avoid compatibility problems with PHP < 5.1.6
      *
-     * @param string $configPath the path to the config file
+     * @param string|null $configPath the path to the config file
      *
-     * @return object
+     * @throws \InvalidArgumentException
+     * @return self
      */
     public static function init($configPath = null)
     {
+        if (!$configPath) {
+            return new self();
+        }
         if (!isset(self::$instances[$configPath])) {
-            self::$instances[$configPath] = new Init($configPath);
+            if (!file_exists($configPath) || !is_readable($configPath)) {
+                throw new \InvalidArgumentException("Invalid config path '$configPath'");
+            }
+            self::$instances[$configPath] = new static(parse_ini_file($configPath, true));
         }
 
         return self::$instances[$configPath];
-    }
-
-    /**
-     * Sets the path to the configuration file
-     *
-     * @param string $path the path to the config
-     *
-     * @throws Exception if file not found
-     * @return void
-     */
-    public function setConfigPath($path)
-    {
-        if (file_exists($path)) {
-            $this->configPath = $path;
-        } else {
-            throw new \InvalidArgumentException(
-                'Configuration file could not be found at ' .
-                htmlspecialchars($path, ENT_QUOTES, 'UTF-8')
-            );
-        }
-    }
-
-    /**
-     * Returns path to configuration file
-     *
-     * @return string the config path
-     */
-    public function getConfigPath()
-    {
-        return $this->configPath;
     }
 
     /**

--- a/tests/IDS/Tests/InitTest.php
+++ b/tests/IDS/Tests/InitTest.php
@@ -24,6 +24,10 @@ use IDS\Init;
 
 class InitTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var \IDS\Init
+     */
+    private $init = null;
     public function setUp()
     {
         $this->init = Init::init(IDS_CONFIG);
@@ -44,11 +48,6 @@ class InitTest extends \PHPUnit_Framework_TestCase
     {
         $config2 = clone $this->init;
         $this->assertEquals($config2, $this->init);
-    }
-
-    public function testInitGetConfigPath()
-    {
-        $this->assertEquals(IDS_CONFIG, $this->init->getConfigPath());
     }
 
     public function testInitSetConfigOverwrite()
@@ -83,7 +82,6 @@ class InitTest extends \PHPUnit_Framework_TestCase
     {
         $init = Init::init();
         $this->assertInstanceOf('\\IDS\\Init', $init);
-        $this->assertSame($init, Init::init());
     }
 }
 


### PR DESCRIPTION
It feels unnecessary , that the `Init`-class is always bound to a specific file path, because nothing made use of the `getConfigPath()` outside of `Init`. Also the multiton-behaviour seems unnecessary. 

This PR allows to instanciate the `Init`-class directly with an `array` of config parameters. `getConfigPath()` and `setConfigPath()` is gone. This should make it easier to integrate IDS into applications, because they can use other connfiguration file formats, the data from an application-wide configuration, or no config-file at all (means "hardcoded" for whatever reasons).

I would have removed the multiton-behaviour completely, but because of unknown reasons many tests start to fail, when `Init::init()` returns new objets, instead of cached ones.
