### PR TITLE
* Cover all files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,50 @@
 /.cache/*
-/.idea/*
 /tmp/*
 /nbproject/
 /lib/IDS/tmp/
 /docs/coverage/
 /vendor/
+
+# Don't include lock file
+composer.lock
+
+# Compiled source #
+###################
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so
+
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+
+# Logs and databases #
+######################
+*.log
+*.sqlite
+
+# OS generated files #
+######################
+.DS_Store*
+ehthumbs.db
+Icon?
+Thumbs.db
+
+# Vim
+*~
+*.sw[a-z]
+
+# PhpStorm (IDE) project files
+.idea/*


### PR DESCRIPTION
I think we should at least ignore files such as *.swp for vim. 
