### PR TITLE
Decouple Monitor-class from request

### DIFF
--- a/lib/IDS/Config/Config.ini.php
+++ b/lib/IDS/Config/Config.ini.php
@@ -18,7 +18,6 @@
 
     ; in case you want to use a different HTMLPurifier source, specify it here
     ; By default, those files are used that are being shipped with PHPIDS
-    HTML_Purifier_Path	= vendors/htmlpurifier/HTMLPurifier.auto.php
     HTML_Purifier_Cache = vendors/htmlpurifier/HTMLPurifier/DefinitionCache/Serializer
 
     ; define which fields contain html and need preparation before
@@ -34,10 +33,6 @@
     exceptions[]    = GET.__utmc
 
     ; you can use regular expressions for wildcard exceptions - example: /.*foo/i
-
-    ; PHPIDS should run with PHP 5.1.2 but this is untested - set
-    ; this value to force compatibilty with minor versions
-    min_php_version = 5.1.6
 
 [Caching]
 

--- a/tests/IDS/Tests/ExceptionTest.php
+++ b/tests/IDS/Tests/ExceptionTest.php
@@ -99,7 +99,7 @@ class ExceptionTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('InvalidArgumentException');
         $this->init->config['General']['filter_type'] = 'xml';
         $this->init->config['General']['filter_path'] = 'IDS/wrong_path';
-        new Monitor(array('test', 'bla'), $this->init);
+        new Monitor($this->init);
     }
 }
 

--- a/tests/IDS/Tests/RuleTest.php
+++ b/tests/IDS/Tests/RuleTest.php
@@ -37,8 +37,8 @@ class RuleTest extends \PHPUnit_Framework_TestCase
     /** @dataProvider getPayloads */
     public function testSingleRules($ruleId, $payload)
     {
-        $monitor = new Monitor(array('payload' => $payload), $this->init);
-        $result = $monitor->run();
+        $monitor = new Monitor($this->init);
+        $result = $monitor->run(array('payload' => $payload));
 
         $event = $result->getEvent('payload');
         $this->assertInstanceOf('IDS\Event', $event);


### PR DESCRIPTION
```
// Before
$monitor = new Monitor($request, $init);
$monitor->run();
// After
$monitor = new Monitor($init);
$monitor->run($request);
```

Allows to
- reuse of a monitor instance
- prepare a monitor instance before it is used (for example in an environment, that makes use of a dependency injection container)
