### PR TITLE
PHP Error: Trying to bind non-variable to PDO statement (PR).

### DIFF
--- a/lib/IDS/Caching/DatabaseCache.php
+++ b/lib/IDS/Caching/DatabaseCache.php
@@ -261,11 +261,11 @@ class DatabaseCache implements CacheInterface
                 )'
             );
 
-            $statement->bindParam(
+            $statement->bindValue(
                 'type',
                 $handle->quote($this->type)
             );
-            $statement->bindParam('data', serialize($data));
+            $statement->bindValue('data', serialize($data));
 
             if (!$statement->execute()) {
                 throw new \PDOException($statement->errorCode());


### PR DESCRIPTION
Fixed #58. Use `bindValue()` instead of `bindParam()` to bind a value returned from a function to a PDO statement. 
